### PR TITLE
Awkward layer can wrap another non-awkward layer

### DIFF
--- a/layered_edm/layer_awkward.py
+++ b/layered_edm/layer_awkward.py
@@ -1,4 +1,3 @@
-from multiprocessing.dummy import Array
 from typing import Any, Callable, Union
 import awkward as ak
 

--- a/layered_edm/layer_awkward.py
+++ b/layered_edm/layer_awkward.py
@@ -50,7 +50,7 @@ class LEDMAwkwardConverter(BaseEDMLayer):
         if isinstance(s, ak.Array):
             return LEDMAwkward(s)
 
-        return LEDMAwkwardConverter(s)
+        raise NotImplementedError()  # pragma: no cover
 
     def single_item_map(self, callback: Callable) -> Any:
         return callback(self)

--- a/layered_edm/layer_awkward.py
+++ b/layered_edm/layer_awkward.py
@@ -1,3 +1,4 @@
+from multiprocessing.dummy import Array
 from typing import Any, Callable, Union
 import awkward as ak
 
@@ -32,13 +33,45 @@ class LEDMAwkward(BaseEDMLayer):
         self._ds = ak.Array(self.ds, with_name=b_name)
 
 
+class LEDMAwkwardConverter(BaseEDMLayer):
+    """Capture another layer, and as we cross it, convert everything
+    into an awkward layer.
+    """
+
+    def __init__(self, ds: BaseEDMLayer):
+        super().__init__(None)
+
+        self._captured_ds = ds
+
+    def __getattr__(self, name: str) -> Any:
+        "Access attributes on the captured guy, and convert to awk"
+        return getattr(self._captured_ds, name).as_awkward()
+
+    def wrap(self, s: Any) -> BaseEDMLayer:
+        if isinstance(s, ak.Array):
+            return LEDMAwkward(s)
+
+        return LEDMAwkwardConverter(s)
+
+    def single_item_map(self, callback: Callable) -> Any:
+        return callback(self)
+
+
 def edm_awk(class_to_wrap: Callable) -> Callable:
     "Creates a class edm based on an awkward array"
 
     def make_it(arr: Union[ak.Array, LEDMAwkward]):
         to_wrap = arr
+
         if isinstance(to_wrap, ak.Array):
+            # Raw awkward array!
             to_wrap = LEDMAwkward(to_wrap)
+
+        if not isinstance(to_wrap, LEDMAwkward):
+            # Convert from some non-awkward type
+            to_wrap = LEDMAwkwardConverter(to_wrap)
+
+        # Look for associated behaviors
         if hasattr(class_to_wrap, "_awk_behaviors"):
             if len(class_to_wrap._awk_behaviors) == 1:
                 to_wrap.add_behavior(class_to_wrap._awk_behaviors[0])

--- a/tests/test_layer_awkward.py
+++ b/tests/test_layer_awkward.py
@@ -1,5 +1,4 @@
 # import pytest
-from ctypes import Union
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable
 import awkward as ak

--- a/tests/test_layer_awkward.py
+++ b/tests/test_layer_awkward.py
@@ -1,8 +1,11 @@
 # import pytest
-from typing import Iterable
+from ctypes import Union
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable
 import awkward as ak
 import pytest
 import layered_edm as ledm
+from layered_edm.base_layer import BaseEDMLayer
 
 # @pytest.fixture
 # def awkward_one():
@@ -127,6 +130,76 @@ def test_aw_jets_behavior_test_2(simple_ds):
 
     assert ak.all(data.x2.as_awkward() == data.x.as_awkward() * 2)
     assert ak.all(data.x3.as_awkward() == data.x.as_awkward() * 3)
+
+
+def test_wrap_other_layer_in_awk_redirect():
+    class my_other_layer(BaseEDMLayer):
+        def __init__(self, given_data=None):
+            @dataclass
+            class data:
+                x = [1, 2, 3]
+                y = [3, 4, 5]
+
+            if given_data is None:
+                given_data = data()
+            super().__init__(given_data)
+
+        def wrap(self, s: Any) -> BaseEDMLayer:
+            return my_other_layer(s)
+
+        def single_item_map(self, callback: Callable) -> Any:
+            return callback(self._ds)
+
+        def as_awkward(self) -> ak.Array:
+            if isinstance(self._ds, my_other_layer):
+                raise NotImplementedError()
+            return ak.Array(self._ds)
+
+    @ledm.edm_awk
+    class my_evt:
+        @property
+        @ledm.remap(lambda e: e.x + 1)
+        def met(self):
+            ...
+
+    data = my_evt(my_other_layer())
+
+    assert str(data.met.as_awkward()) == str(ak.Array([2, 3, 4]))
+
+
+def test_wrap_other_layer_in_awk():
+    class my_other_layer(BaseEDMLayer):
+        def __init__(self, given_data=None):
+            @dataclass
+            class data:
+                x = [1, 2, 3]
+                y = [3, 4, 5]
+
+            if given_data is None:
+                given_data = data()
+            super().__init__(given_data)
+
+        def wrap(self, s: Any) -> BaseEDMLayer:
+            return my_other_layer(s)
+
+        def single_item_map(self, callback: Callable) -> Any:
+            return callback(self._ds)
+
+        def as_awkward(self) -> ak.Array:
+            if isinstance(self._ds, my_other_layer):
+                raise NotImplementedError()
+            return ak.Array(self._ds)
+
+    @ledm.edm_awk
+    class my_evt:
+        @property
+        @ledm.remap(lambda e: e.x + 1)
+        def met(self):
+            ...
+
+    data = my_evt(my_other_layer())
+
+    assert str(data.y) == str(ak.Array([3, 4, 5]))
 
 
 # def test_return_as_property(awkward_one):


### PR DESCRIPTION
* Convert non-awkward layers to awkward before use

Note: there may be cases of wrapped upon wrapped layers that might accidentally be treated as an awkward layer.

Fixes #7