### PR TITLE
Remove virtual functionality

### DIFF
--- a/layered_edm/layer_servicex.py
+++ b/layered_edm/layer_servicex.py
@@ -1,7 +1,6 @@
 import ast
 from typing import Callable, Union
 
-import awkward as ak
 from func_adl import ObjectStream
 from func_adl.util_ast import parse_as_ast
 
@@ -20,10 +19,7 @@ class LEDMServiceX(BaseEDMLayer):
         return self.ds
 
     def as_awkward(self):
-        def generate():
-            return self.ds.AsAwkwardArray().value()
-
-        return ak.virtual(generate)
+        return self.ds.AsAwkwardArray().value()
 
     def wrap(self, s: ObjectStream):
         return LEDMServiceX(s)

--- a/tests/test_layer_servicex.py
+++ b/tests/test_layer_servicex.py
@@ -139,6 +139,22 @@ def test_as_awk(simple_awk_ds):
     assert simple_awk_ds.count == 1
 
 
+def test_as_awk_repr(simple_awk_ds):
+    @ledm.edm_sx
+    class my_evt:
+        @property
+        @ledm.remap(lambda ds: ds.Select(lambda e: e.MissingET().First()))
+        def met(self):
+            ...
+
+    @ledm.edm_sx
+    class empty_evt:
+        ...
+
+    data = my_evt(empty_evt(simple_awk_ds))
+    assert repr(data.met.as_awkward()) == repr(ak.Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+
+
 class _test_sub_objs:
     @property
     @ledm.remap(lambda so: so.prop())


### PR DESCRIPTION
Remove virtual functoinality. This is because we are mostly loading uproot arrays, and those are virtual since we are doing lazy loads.

Fixes #16