### PR TITLE
Adding Awkward Behaviors to SX Objects

### DIFF
--- a/layered_edm/layer_awkward.py
+++ b/layered_edm/layer_awkward.py
@@ -1,12 +1,10 @@
 from typing import Any, Callable, Union
 import awkward as ak
 
+from layered_edm.util_types import class_behavior
+
 from .layer_nested import BaseTemplateEDMLayer
 from .base_layer import BaseEDMLayer
-
-
-def _get_behavior_name(behavior: type) -> str:
-    return behavior.__name__
 
 
 class LEDMAwkward(BaseEDMLayer):
@@ -22,13 +20,15 @@ class LEDMAwkward(BaseEDMLayer):
     def as_awkward(self):
         return self.ds
 
-    def add_behavior(self, b: type):
-        "Add awkward behavior to our array"
-        b_name = _get_behavior_name(b)
-        # TODO: Make this unique per array, not global, by using the
-        #       `behavior` keyword argument.
-        if ("*", b_name) not in ak.behavior:
-            ak.behavior["*", b_name] = b
+    def add_behavior(self, b_name: str):
+        """Add a behavior to the awkward array.
+
+        WARNING: call this only once. A second time and the
+        first behavior will be forgotten!
+
+        Args:
+            b_name (str): The name of the new behavior to set us up as.
+        """
         self._ds = ak.Array(self.ds, with_name=b_name)
 
 
@@ -59,7 +59,7 @@ class LEDMAwkwardConverter(BaseEDMLayer):
         raise NotImplementedError()  # pragma: no cover
 
 
-def edm_awk(class_to_wrap: Callable) -> Callable:
+def edm_awk(class_to_wrap: type) -> Callable:
     "Creates a class edm based on an awkward array"
 
     def make_it(arr: Union[ak.Array, LEDMAwkward]):
@@ -74,16 +74,11 @@ def edm_awk(class_to_wrap: Callable) -> Callable:
             to_wrap = LEDMAwkwardConverter(to_wrap)
 
         # Look for associated behaviors
-        if hasattr(class_to_wrap, "_awk_behaviors"):
-            if len(class_to_wrap._awk_behaviors) == 1:
-                to_wrap.add_behavior(class_to_wrap._awk_behaviors[0])
-            else:
+        behaviors = class_behavior(class_to_wrap)
+        if behaviors is not None:
+            to_wrap.add_behavior(behaviors)
 
-                class all_behaviors(*(class_to_wrap._awk_behaviors)):  # type: ignore
-                    pass
-
-                to_wrap.add_behavior(all_behaviors)
-
+        # And create the base class
         return BaseTemplateEDMLayer(to_wrap, class_to_wrap)
 
     return make_it

--- a/tests/test_layer_nested.py
+++ b/tests/test_layer_nested.py
@@ -26,7 +26,7 @@ class simple_array_layer(BaseEDMLayer):
         return callback(self.ds)
 
     def as_awkward(self) -> ak.Array:
-        raise NotImplementedError()  # pragma: no cover
+        return ak.Array([1, 2, 3, 4, 5])
 
 
 @dataclass


### PR DESCRIPTION
* Using `ledm.add_awk_behavior` on a sx object
* Will apply if you do `as_awkward` on that object.
* Turn off virtual array generation - incompatible with the above

Fixes #18