### PR TITLE
Logging for when we materialize a servicex array

### DIFF
--- a/layered_edm/layer_servicex.py
+++ b/layered_edm/layer_servicex.py
@@ -1,5 +1,6 @@
 import ast
 from typing import Callable, Union
+import logging
 
 from func_adl import ObjectStream
 from func_adl.util_ast import parse_as_ast
@@ -7,6 +8,7 @@ from func_adl.util_ast import parse_as_ast
 from layered_edm.layer_nested import BaseTemplateEDMLayer
 
 from .base_layer import BaseEDMLayer
+from .util_compat import unparse
 
 # TODO: the parse_as_ast should that be exported or put in a separate package?
 
@@ -19,6 +21,8 @@ class LEDMServiceX(BaseEDMLayer):
         return self.ds
 
     def as_awkward(self):
+        logger = logging.getLogger(__name__)
+        logger.debug(f"Issuing ServiceX Query for {unparse(self.ds.query_ast)}")
         return self.ds.AsAwkwardArray().value()
 
     def wrap(self, s: ObjectStream):

--- a/layered_edm/util_compat.py
+++ b/layered_edm/util_compat.py
@@ -1,0 +1,13 @@
+import ast
+import sys
+
+if sys.version_info < (3, 9):
+
+    def unparse(a: ast.AST):
+        "Unparse an ast"
+        return ast.dump(a, annotate_fields=False)
+
+else:
+
+    def unparse(a: ast.AST):
+        return ast.unparse(a)

--- a/tests/test_layer_servicex.py
+++ b/tests/test_layer_servicex.py
@@ -165,6 +165,30 @@ def test_as_awk(simple_awk_ds):
     assert simple_awk_ds.count == 1
 
 
+def test_as_awk_logging(simple_awk_ds, caplog):
+    import logging
+
+    logging.basicConfig()
+    logger = logging.getLogger("layered_edm")
+    logger.setLevel(logging.DEBUG)
+
+    @ledm.edm_sx
+    class my_evt:
+        @property
+        @ledm.remap(lambda ds: ds.Select(lambda e: e.MissingET().First()))
+        def met(self):
+            ...
+
+    @ledm.edm_sx
+    class empty_evt:
+        ...
+
+    data = my_evt(empty_evt(simple_awk_ds))
+    data.met.as_awkward()
+
+    assert len(caplog.text) > 0
+
+
 def test_as_awk_virtual(simple_awk_ds_virtual):
     @ledm.edm_sx
     class my_evt:


### PR DESCRIPTION
* Each time we issue a servicex query, generate a DEBUG level message.

Fixes #25