### PR TITLE
Virtual Arrays With Behaviors aren't Materialized Right Away

### DIFF
--- a/layered_edm/layer_nested.py
+++ b/layered_edm/layer_nested.py
@@ -136,8 +136,9 @@ class BaseTemplateEDMLayer(BaseEDMLayer):
 
         items = {
             item: ak.virtual(
-                lambda: ak.repartition(getattr(self, item).as_awkward(), None),
+                lambda itm: ak.repartition(getattr(self, itm).as_awkward(), None),
                 length=n_items,
+                args=(item,),
             )
             for item in all_items[1:]
         }

--- a/layered_edm/layer_nested.py
+++ b/layered_edm/layer_nested.py
@@ -136,9 +136,9 @@ class BaseTemplateEDMLayer(BaseEDMLayer):
 
         items = {
             item: ak.virtual(
-                lambda itm: ak.repartition(getattr(self, itm).as_awkward(), None),
+                lambda o, itm: ak.repartition(getattr(o, itm).as_awkward(), None),
                 length=n_items,
-                args=(item,),
+                args=(self, item),
             )
             for item in all_items[1:]
         }

--- a/layered_edm/layer_nested.py
+++ b/layered_edm/layer_nested.py
@@ -148,10 +148,8 @@ class BaseTemplateEDMLayer(BaseEDMLayer):
         )
 
         # Build the array
-        return ak.Array(
-            items,
-            with_name=behavior_name,
-        )
+        a = ak.Array(items)
+        return ak.with_parameter(a, "__record__", behavior_name)
 
 
 class IterableTemplateEDMLayer(BaseTemplateEDMLayer):

--- a/tests/test_layer_servicex.py
+++ b/tests/test_layer_servicex.py
@@ -314,7 +314,7 @@ def test_simple_collection_as_awk(simple_awk_ds):
     assert isinstance(awk_data, ak.Array)
     t = ak.type(awk_data)
     assert t.length == 10
-    assert t.keys() == ["px", "py"]
+    assert set(t.keys()) == set(["px", "py"])
     assert len(awk_data) == 10
     assert simple_awk_ds.count == 2
 

--- a/tests/test_layer_servicex.py
+++ b/tests/test_layer_servicex.py
@@ -319,6 +319,38 @@ def test_simple_collection_as_awk(simple_awk_ds):
     assert simple_awk_ds.count == 2
 
 
+def test_simple_collection_with_behavior(simple_awk_ds):
+    "A behavior can alter how a virtual array is materalized - make sure we work around it"
+
+    class behave(ak.Array):
+        @property
+        def mine(self) -> float:
+            return self.px
+
+    @ledm.add_awk_behavior(behave)
+    class jet:
+        @property
+        @ledm.remap(lambda e: e.px())
+        def px(self) -> float:
+            ...
+
+        @property
+        @ledm.remap(lambda e: e.py())
+        def py(self) -> float:
+            ...
+
+    @ledm.edm_sx
+    class my_evt:
+        @property
+        @ledm.remap(lambda e: e.subs())
+        def subs(self) -> Iterable[jet]:
+            ...
+
+    data = my_evt(simple_awk_ds)
+    data.subs.as_awkward()
+    assert simple_awk_ds.count == 1
+
+
 def test_simple_collection_as_v_awk(simple_awk_ds_virtual_concat):
     "Virtual collection - simulates the uproot case where we load data from uproot"
 
@@ -377,3 +409,37 @@ def test_simple_collection_awk_behavior(simple_awk_ds):
     data = my_evt(simple_awk_ds)
     awk_data = data.subs.as_awkward()
     assert str(awk_data.px * 2) == str(awk_data.px2)
+
+
+def test_it_out():
+    class my_behavior(ak.Array):
+        @property
+        def px2(self):
+            return 2 * self.px2
+
+    ak.behavior["my_behavior"] = my_behavior
+    ak.behavior["*", "my_behavior"] = my_behavior
+
+    count = 0
+
+    def generate1():
+        print("generate1")
+        nonlocal count
+        count += 1
+        return ak.Array([1, 2, 3])
+
+    def generate2():
+        print("generate2")
+        nonlocal count
+        count += 1
+        return ak.Array([4, 5, 6])
+
+    a1 = ak.virtual(generate1, length=3)
+    a2 = ak.virtual(generate2, length=3)
+
+    print("building a")
+    a = ak.Array({"a1": a1, "a2": a2})
+    a = ak.with_parameter(a, "__record__", "my_behavior")
+    print("accessing a")
+    print(f"a.a1: {a.a1}")
+    assert count == 1


### PR DESCRIPTION
* Add tests to make sure virtual virtual arrays don't cause crashes
* Fix bug where we weren't gluing together arrays that were grabbed from multiple files
* Work around `awkward` behavior causing a full array to materalize.

With this change virtual arrays with a behavior are no longer materalized when they are created!