### PR TITLE
awk registration function improvements

### DIFF
--- a/layered_edm/util_types.py
+++ b/layered_edm/util_types.py
@@ -132,6 +132,11 @@ def class_behavior(class_to_wrap: Callable) -> Optional[str]:
     if behavior_list is None:
         return None
 
+    # Call all the callback functions
+    for cb in behavior_list:
+        if cb.register_callback is not None:
+            cb.register_callback()
+
     behavior_name: Optional[str] = None
     behavior_object = None
     if len(behavior_list) == 1:
@@ -144,11 +149,6 @@ def class_behavior(class_to_wrap: Callable) -> Optional[str]:
 
         behavior_name = str(uuid.uuid4())
         behavior_object = all_behaviors
-
-    # Call all the callback functions
-    for cb in behavior_list:
-        if cb.register_callback is not None:
-            cb.register_callback()
 
     # Make sure the behavior is registered
     if ("*", behavior_name) not in ak.behavior:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import ast
 from typing import Union
 import sys
 
+import pytest
+
 # Hide ast.unparse
 if sys.version_info < (3, 9):
 
@@ -16,3 +18,10 @@ else:
         if isinstance(node, str):
             return node
         return ast.unparse(node)
+
+
+@pytest.fixture
+def ak_behavior(mocker):
+    the_dict = {}
+    mocker.patch("layered_edm.util_types.ak.behavior", the_dict)
+    return the_dict

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,20 @@ else:
 
 @pytest.fixture
 def ak_behavior(mocker):
+    "Patch the awkward behavior dictionary in `util_types`"
     the_dict = {}
     mocker.patch("layered_edm.util_types.ak.behavior", the_dict)
     return the_dict
+
+
+@pytest.fixture
+def simple_ds():
+    import awkward as ak
+
+    return ak.Array(
+        [
+            [{"x": 1}, {"x": 2}, {"x": 3}],
+            [],
+            [{"x": 4}, {"x": 5}],
+        ]
+    )

--- a/tests/test_layer_awkward.py
+++ b/tests/test_layer_awkward.py
@@ -7,17 +7,6 @@ import layered_edm as ledm
 from layered_edm.base_layer import BaseEDMLayer
 
 
-@pytest.fixture
-def simple_ds():
-    return ak.Array(
-        [
-            [{"x": 1}, {"x": 2}, {"x": 3}],
-            [],
-            [{"x": 4}, {"x": 5}],
-        ]
-    )
-
-
 def test_aw_in_layer(simple_ds):
     @ledm.edm_awk
     class my_evt:
@@ -62,7 +51,7 @@ def test_aw_jets_iterable(simple_ds):
     assert r.tolist() == [[1, 2, 3], [], [4, 5]]
 
 
-def test_aw_jets_behavior_test(simple_ds):
+def test_aw_jets_behavior_test(simple_ds, ak_behavior):
     "Test adding a pre-existing, very simple, behavior"
 
     class awk_my_behavior(ak.Array):
@@ -88,7 +77,7 @@ def test_aw_jets_behavior_test(simple_ds):
     assert ak.all(data.x2.as_awkward() == data.x.as_awkward() * 2)
 
 
-def test_aw_jets_behavior_test_2(simple_ds):
+def test_aw_jets_behavior_test_2(simple_ds, ak_behavior):
     "Test adding a pre-existing, very simple, behavior"
 
     class awk_my_behavior_1(ak.Array):
@@ -224,7 +213,7 @@ def test_aw_jets_behavior_by_name(simple_ds):
     assert ak.all(data.x2.as_awkward() == data.x.as_awkward() * 2)
 
 
-def test_aw_jets_behavior_by_name_late(simple_ds):
+def test_aw_jets_behavior_by_name_late(simple_ds, ak_behavior):
     "Test adding a pre-existing, very simple, behavior"
 
     class awk_my_behavior(ak.Array):
@@ -253,7 +242,7 @@ def test_aw_jets_behavior_by_name_late(simple_ds):
     assert ak.all(data.x2.as_awkward() == data.x.as_awkward() * 2)
 
 
-def test_aw_jets_behavior_by_name_bad():
+def test_aw_jets_behavior_by_name_bad(ak_behavior):
     "Test adding a pre-existing, very simple, behavior"
 
     class awk_my_behavior(ak.Array):
@@ -278,7 +267,7 @@ def test_aw_jets_behavior_by_name_bad():
     assert "test_aw_jets_behavior_by_name_bad" in str(e)
 
 
-def test_aw_jets_behavior_right_name(simple_ds):
+def test_aw_jets_behavior_right_name(simple_ds, ak_behavior):
     "Test adding a pre-existing, very simple, behavior"
 
     class awk_my_behavior(ak.Array):
@@ -286,7 +275,8 @@ def test_aw_jets_behavior_right_name(simple_ds):
         def x2(self):
             return self.x * 2
 
-    ak.behavior["test_aw_jets_behavior_by_name"] = awk_my_behavior
+    ak_behavior["test_aw_jets_behavior_by_name"] = awk_my_behavior
+    ak_behavior["*", "test_aw_jets_behavior_by_name"] = awk_my_behavior
 
     @ledm.add_awk_behavior("test_aw_jets_behavior_by_name")
     class jet:
@@ -310,7 +300,7 @@ def test_aw_jets_behavior_right_name(simple_ds):
     assert "test_aw_jets_behavior_by_name" in str(a.layout)
 
 
-def test_aw_jets_behavior_late_decl(simple_ds):
+def test_aw_jets_behavior_late_decl(simple_ds, ak_behavior):
     "Test adding a pre-existing, very simple, behavior"
 
     def decl_behavior():

--- a/tests/test_util_types.py
+++ b/tests/test_util_types.py
@@ -1,0 +1,97 @@
+import awkward as ak
+import pytest
+from layered_edm.util_types import append_awk_behavior_to_class, class_behavior
+
+
+def test_class_behavior_none(ak_behavior):
+    class my_test:
+        pass
+
+    assert class_behavior(my_test) == None
+
+
+def test_class_behavior_add_one(ak_behavior):
+    class my_test:
+        pass
+
+    class hi_there(ak.Array):
+        def __init__(self):
+            pass
+
+    append_awk_behavior_to_class(my_test, hi_there, None)
+    assert class_behavior(my_test) == "hi_there"
+
+
+def test_class_behavior_add_two(ak_behavior):
+    class my_test:
+        pass
+
+    class hi_there_1(ak.Array):
+        def __init__(self):
+            pass
+
+    class hi_there_2(ak.Array):
+        def __init__(self):
+            pass
+
+    append_awk_behavior_to_class(my_test, hi_there_1, None)
+    append_awk_behavior_to_class(my_test, hi_there_2, None)
+    r = class_behavior(my_test)
+
+    assert r != "hi_there_1"
+    assert r != "hi_there_2"
+
+
+def test_class_behavior_add_two_with_registration(ak_behavior):
+    class my_test:
+        pass
+
+    class hi_there_1(ak.Array):
+        def __init__(self):
+            pass
+
+    class hi_there_2(ak.Array):
+        def __init__(self):
+            pass
+
+    def reg_2():
+        ak_behavior["hi_there_2"] = hi_there_2
+        ak_behavior["*", "hi_there_2"] = hi_there_2
+
+    append_awk_behavior_to_class(my_test, hi_there_1, None)
+    append_awk_behavior_to_class(my_test, "hi_there_2", reg_2)
+    r = class_behavior(my_test)
+
+    assert r != "hi_there_1"
+    assert r != "hi_there_2"
+
+
+def test_class_behavior_callback(ak_behavior):
+    class my_test:
+        pass
+
+    class hi_there(ak.Array):
+        def __init__(self):
+            pass
+
+    seen = False
+
+    def call_me():
+        nonlocal seen
+        seen = True
+
+    append_awk_behavior_to_class(my_test, hi_there, call_me)
+    class_behavior(my_test)
+
+    assert seen
+
+
+def test_class_behavior_unknown(ak_behavior):
+    class my_test:
+        pass
+
+    append_awk_behavior_to_class(my_test, "hi_there", None)
+    with pytest.raises(ValueError) as e:
+        class_behavior(my_test)
+
+    assert "hi_there" in str(e)

--- a/tests/test_util_types.py
+++ b/tests/test_util_types.py
@@ -7,7 +7,7 @@ def test_class_behavior_none(ak_behavior):
     class my_test:
         pass
 
-    assert class_behavior(my_test) == None
+    assert class_behavior(my_test) is None
 
 
 def test_class_behavior_add_one(ak_behavior):


### PR DESCRIPTION
* Make sure registration function is always called before behavior is accessed
* Created a pytest fixture for awkward behavior
* Use the fixture for behavior in other places in test suite.

Fixes #37